### PR TITLE
Update newsletter link to redirect to substack

### DIFF
--- a/src/components/molecules/main-nav/main-nav.tsx
+++ b/src/components/molecules/main-nav/main-nav.tsx
@@ -50,8 +50,11 @@ const MainNav = ({ navList }: MainNavProps) => {
             <DrawerBody>
               <ul>
                 {navList.map((navItem, index) =>
-                  <li key={index} className={`py-2 text-right ${index !== 0 && "border-t"}`}>
+                  <li key={index} className={`flex items-center justify-end gap-2 py-2 ${index !== 0 && "border-t"}`}>
                     <NavLink {...navItem} />
+                    {
+                      navItem.externalLink && <Icon Icon={FiExternalLink} size={22} iconAlt="external link for TechIsHiring newsletter" />
+                    }
                   </li>
                 )}
               </ul>

--- a/src/components/molecules/main-nav/main-nav.tsx
+++ b/src/components/molecules/main-nav/main-nav.tsx
@@ -10,7 +10,7 @@ import {
 import { Fragment } from "react";
 import NavLink from "components/atoms/nav-link/nav-link";
 import Icon from "components/atoms/icon/icon";
-import { FiMenu } from "react-icons/fi";
+import { FiMenu, FiExternalLink } from "react-icons/fi";
 import { useRouter } from "next/router";
 
 interface MainNavProps {
@@ -26,8 +26,11 @@ const MainNav = ({ navList }: MainNavProps) => {
       <ul className="lg:flex gap-4 hidden">
         {navList.map((navItem, index) =>
           <Fragment key={index}>
-            <li>
+            <li className="flex items-center gap-2">
               <NavLink activeLink={router.pathname === navItem.url} {...navItem} />
+              {
+                navItem.externalLink && <Icon Icon={FiExternalLink} size={22} iconAlt="external link for TechIsHiring newsletter" />
+              }
             </li>
           </Fragment>
         )}

--- a/src/lib/hooks/use-nav.tsx
+++ b/src/lib/hooks/use-nav.tsx
@@ -6,8 +6,9 @@ const useMainNav = () => {
       text: "Home"
     },
     {
-      url: "/newsletter",
-      text: "Newsletter"
+      url: "https://techishiring.substack.com/",
+      text: "Newsletter",
+      externalLink: true
     },
     {
       url: "/about",

--- a/src/stories/molecules/main-nav.stories.tsx
+++ b/src/stories/molecules/main-nav.stories.tsx
@@ -9,7 +9,12 @@ const navList: NavLink[] = [
     url: "https://www.google.com",
     text: "test",
     externalLink: true
+  },
+  {
+    url: "https://www.google.com",
+    text: "test 2"
   }
+
 ];
 
 export default storyConfig;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

With Revue being sunsetted, the newsletter was migrated to Substack but the link was never updated and the newsletter page no longer worked.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #33
Fixes #45

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

n/a

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally

## Screenshots (if appropriate):
![localhost_3000_ (1)](https://user-images.githubusercontent.com/11777161/217286712-0f5048a3-8562-463d-8e52-191b7d5d3d85.png)
![localhost_3000_ (2)](https://user-images.githubusercontent.com/11777161/217295503-35ccbdae-6d7f-457e-9906-2653eb26bff2.png)
