### PR TITLE
Make contact page mobile bg image visible up to 1024px width #90

### DIFF
--- a/src/components/organisms/contact-content/contact-content.tsx
+++ b/src/components/organisms/contact-content/contact-content.tsx
@@ -17,7 +17,7 @@ const ContactContent = () => {
       
       <div className="w-full lg:w-1/2 lg:px-32 px-5 md:px-10 mt-20 flex flex-col">
 
-        <div className="md:hidden absolute right-0 top-[6rem]">
+        <div className="lg:hidden absolute right-0 top-[6rem]">
           <Image src= {contactMobileImg} alt="contact form mobile image" width={150} height={180} />
         </div>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,7 +14,7 @@ module.exports = {
       screens: {
         xs: "425px",
         // => @media (min-width: 425px) { ... }
-
+        'lg':'1025px',
         "2xl": "1440px"
         // => @media (min-width: 1440px) { ... }
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,7 +14,6 @@ module.exports = {
       screens: {
         xs: "425px",
         // => @media (min-width: 425px) { ... }
-        'lg':'1025px',
         "2xl": "1440px"
         // => @media (min-width: 1440px) { ... }
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Done the changes for 768-1024px, now the mobile background is showing upto 1024px.
pr is for issue number #90

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves: <!-- Add issue number here, i.e. #27. -->

<!-- If this PR fixes multiple issues, copy previous line for each issue that this PR addresses -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
