### PR TITLE
Fix: #75 Website no longer stretches past 1920px

### DIFF
--- a/cypress/e2e/homepage.cy.ts
+++ b/cypress/e2e/homepage.cy.ts
@@ -7,6 +7,6 @@ describe("Homepage", () => {
     cy.title().should("include", "TechIsHiring");
     cy.get("header").should("be.visible");
     cy.get('.sticky > :nth-child(1) > a > .chakra-text').contains('TechIsHiring');
-    cy.get('header > nav > ul').should('be.visible');
+    cy.get('header > div > nav > ul').should('be.visible');
   });
 });

--- a/src/components/atoms/card/card.tsx
+++ b/src/components/atoms/card/card.tsx
@@ -23,7 +23,7 @@ type CardProps = IsArticle | IsSection | NeitherArticleOrSection;
 const Card = ({ children, className, section, article }: CardProps) => {
   const cardClassDefinition = `${
     className ? className : ""
-  } w-full p-8 shadow-md rounded-lg border-grey`;
+  } w-full p-8 shadow-md rounded-lg`;
 
   return (
     <>

--- a/src/components/atoms/card/card.tsx
+++ b/src/components/atoms/card/card.tsx
@@ -23,7 +23,7 @@ type CardProps = IsArticle | IsSection | NeitherArticleOrSection;
 const Card = ({ children, className, section, article }: CardProps) => {
   const cardClassDefinition = `${
     className ? className : ""
-  } w-full p-8 shadow-md rounded-lg border-[1px] border-grey`;
+  } w-full p-8 shadow-md rounded-lg border-grey`;
 
   return (
     <>

--- a/src/components/molecules/highlights-details/highlights-details.tsx
+++ b/src/components/molecules/highlights-details/highlights-details.tsx
@@ -3,7 +3,7 @@ import { TwitterTweetEmbed } from "react-twitter-embed";
 
 const HighlightsDetails = () => {
   return (
-    <section className="flex flex-col lg:flex-row justify-center gap-10">
+    <section className="flex flex-col xl:flex-row justify-center gap-10">
       <TwitterTweetEmbed
         tweetId="1588617719016198144"
         placeholder={<Spinner />}

--- a/src/components/organisms/footer/footer.tsx
+++ b/src/components/organisms/footer/footer.tsx
@@ -218,7 +218,7 @@ const Footer = () => {
 
   return (
     <footer className="flex justify-center w-full bg-[#134D82]">
-      <div className="hidden md:block 2xl:w-max-screen-size px-4 pt-6 pb-8 md:px-5 md:pb-16 lg:px-14">
+      <div className="hidden md:block 3xl:w-max-screen-size px-4 pt-6 pb-8 md:px-5 md:pb-16 lg:px-14">
         <DesktopFooter mobileNav={navItems} />
       </div>
       <div className="md:hidden">

--- a/src/components/organisms/footer/footer.tsx
+++ b/src/components/organisms/footer/footer.tsx
@@ -217,8 +217,8 @@ const Footer = () => {
   });
 
   return (
-    <footer className="w-full bg-[#134D82] px-4 pt-6 pb-8 md:px-5 md:pb-16 lg:px-14">
-      <div className="hidden md:block">
+    <footer className="flex justify-center w-full bg-[#134D82]">
+      <div className="hidden md:block 2xl:w-max-screen-size px-4 pt-6 pb-8 md:px-5 md:pb-16 lg:px-14">
         <DesktopFooter mobileNav={navItems} />
       </div>
       <div className="md:hidden">

--- a/src/components/organisms/header/header.tsx
+++ b/src/components/organisms/header/header.tsx
@@ -7,7 +7,7 @@ const Header = () => {
 
   return (
     <header className="flex justify-center sticky top-0 z-10 w-full border-b bg-white py-2">
-      <div className="flex items-center w-full 2xl:w-max-screen-size justify-between px-4 h-24">
+      <div className="flex items-center w-full 3xl:w-max-screen-size justify-between px-4 h-24">
         <Logo />
         <MainNav navList={navList} />
       </div>

--- a/src/components/organisms/header/header.tsx
+++ b/src/components/organisms/header/header.tsx
@@ -6,11 +6,11 @@ const Header = () => {
   const navList = useMainNav();
 
   return (
-    <header className="sticky top-0 z-10 flex h-24 w-full items-center justify-between border-b bg-white px-4 py-2">
-      <div className="flex items-center">
+    <header className="flex justify-center sticky top-0 z-10 w-full border-b bg-white px-4 py-2">
+      <div className="flex items-center w-full 2xl:w-max-screen-size justify-between h-24">
         <Logo />
+        <MainNav navList={navList} />
       </div>
-      <MainNav navList={navList} />
     </header>
   );
 };

--- a/src/components/organisms/header/header.tsx
+++ b/src/components/organisms/header/header.tsx
@@ -6,8 +6,8 @@ const Header = () => {
   const navList = useMainNav();
 
   return (
-    <header className="flex justify-center sticky top-0 z-10 w-full border-b bg-white px-4 py-2">
-      <div className="flex items-center w-full 2xl:w-max-screen-size justify-between h-24">
+    <header className="flex justify-center sticky top-0 z-10 w-full border-b bg-white py-2">
+      <div className="flex items-center w-full 2xl:w-max-screen-size justify-between px-4 h-24">
         <Logo />
         <MainNav navList={navList} />
       </div>

--- a/src/components/templates/layouts/default-layout.tsx
+++ b/src/components/templates/layouts/default-layout.tsx
@@ -13,7 +13,7 @@ const DefaultLayout = ({ children }: { children: React.ReactNode }) => {
       </Head>
       <div className="flex min-h-screen flex-col items-center justify-center">
         <Header />
-        <main className="flex w-full flex-1 flex-col">
+        <main className="flex w-full 2xl:w-max-screen-size pass-max-screen:border-x-2 flex-1 flex-col">
           {children}
         </main>
         <Footer />

--- a/src/components/templates/layouts/default-layout.tsx
+++ b/src/components/templates/layouts/default-layout.tsx
@@ -13,7 +13,7 @@ const DefaultLayout = ({ children }: { children: React.ReactNode }) => {
       </Head>
       <div className="flex min-h-screen flex-col items-center justify-center">
         <Header />
-        <main className="flex w-full 2xl:w-max-screen-size pass-max-screen:border-x-2 flex-1 flex-col">
+        <main className="flex w-full 3xl:w-max-screen-size pass-max-screen:border-x-2 flex-1 flex-col">
           {children}
         </main>
         <Footer />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,9 +19,9 @@ module.exports = {
         "2xl": "1440px",
         // => @media (min-width: 1440px) { ... }
         "3xl": "1920px",
-        // => @media (min-width: 1440px) { ... }
+        // => @media (min-width: 1920px) { ... }
         "pass-max-screen": "1921px"
-        // => @media (min-width: 1440px) { ... }
+        // => @media (min-width: 1921px) { ... }
       },
       fontFamily: {
         inter: ["Inter", "sans-serif"]

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,9 @@ module.exports = {
   ],
   theme: {
     extend: {
-      
+      spacing: {
+        "max-screen-size": "1440px"
+      },
       gridTemplateColumns: {
         autodesktop: "repeat(auto-fit, minmax(410px, 1fr))",
         automobile: "repeat(auto-fit, minmax(300px, 1fr))"
@@ -14,7 +16,9 @@ module.exports = {
       screens: {
         xs: "425px",
         // => @media (min-width: 425px) { ... }
-        "2xl": "1440px"
+        "2xl": "1440px",
+        // => @media (min-width: 1440px) { ... }
+        "pass-max-screen": "1441px"
         // => @media (min-width: 1440px) { ... }
       },
       fontFamily: {
@@ -27,7 +31,6 @@ module.exports = {
         dark: "#000000",
         altDark: "#222222",
         altWhite: "#F0F0F0"
-
       }
     }
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ module.exports = {
   theme: {
     extend: {
       spacing: {
-        "max-screen-size": "1440px"
+        "max-screen-size": "1920px"
       },
       gridTemplateColumns: {
         autodesktop: "repeat(auto-fit, minmax(410px, 1fr))",
@@ -18,7 +18,9 @@ module.exports = {
         // => @media (min-width: 425px) { ... }
         "2xl": "1440px",
         // => @media (min-width: 1440px) { ... }
-        "pass-max-screen": "1441px"
+        "3xl": "1920px",
+        // => @media (min-width: 1440px) { ... }
+        "pass-max-screen": "1921px"
         // => @media (min-width: 1440px) { ... }
       },
       fontFamily: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Website would stretch to fill screen even if a screen size was particularly large. This is to prevent that from happening.

Also there was an issue where TechIsHiring Highlight Tweets would stretch out of screen at around the screen size of 1024px. Fixed issue by increasing the size that component uses flex row.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves: #75 <!-- Add issue number here, i.e. #27. -->
Resolves: #115

<!-- If this PR fixes multiple issues, copy previous line for each issue that this PR addresses -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See above.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally. Will also be tested in the PR preview.

## Screenshots (if appropriate):

![localhost_3000_ (7)](https://user-images.githubusercontent.com/11777161/235210258-03d0b068-e17e-4e48-864a-1b253c331491.png)
![localhost_3000_ (10)](https://user-images.githubusercontent.com/11777161/235210475-fcc4b9b6-10b5-4122-bc8e-2ef8bdc71aca.png)
