### PR TITLE
fix: Fixed Footer width issue

### DIFF
--- a/src/components/organisms/footer/footer.tsx
+++ b/src/components/organisms/footer/footer.tsx
@@ -218,7 +218,7 @@ const Footer = () => {
 
   return (
     <footer className="flex justify-center w-full bg-[#134D82]">
-      <div className="hidden md:block 3xl:w-max-screen-size px-4 pt-6 pb-8 md:px-5 md:pb-16 lg:px-14">
+      <div className="hidden w-full md:block 3xl:w-max-screen-size px-4 pt-6 pb-8 md:px-5 md:pb-16 lg:px-14">
         <DesktopFooter mobileNav={navItems} />
       </div>
       <div className="md:hidden">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Added width: 100% to footer so that whenever the window is less than 1920px, the footer content will be the full size of the footer.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves: #117 <!-- Add issue number here, i.e. #27. -->

<!-- If this PR fixes multiple issues, copy previous line for each issue that this PR addresses -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes an issue where the footer only filled up the space needed to render the content.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in different screen sizes locally. Will also test in preview as well.

## Screenshots (if appropriate):

![localhost_3000_ (11)](https://github.com/TechIsHiring/techishiring-website/assets/11777161/080bd5e9-1737-471f-b825-e69ca54a9dff)