### PR TITLE
Added Contact us Image Rendering Test

### DIFF
--- a/cypress/e2e/contactuspage.cy.ts
+++ b/cypress/e2e/contactuspage.cy.ts
@@ -1,0 +1,22 @@
+
+describe("Contact Us Image Rendering", () => {
+    beforeEach(() => {
+        cy.visit("http://localhost:3000/contact",  { timeout: 30000 });
+      });
+
+    it("Image rendering on desktop", () =>{
+        cy.viewport('macbook-11')
+        cy.get('[data-testid="desktop"] > img')
+        .should('be.visible')
+        .and('have.prop', 'naturalWidth')
+        .should('be.greaterThan', 0)
+    })
+
+      it("Background Image rendering on mobile", () =>{
+        cy.viewport('iphone-5')
+        cy.get('[data-testid="mobile"] > img')
+        .should("be.visible")
+        .and('have.prop', 'naturalWidth')
+        .should('be.greaterThan', 0)
+     })
+})

--- a/src/components/organisms/contact-content/contact-content.tsx
+++ b/src/components/organisms/contact-content/contact-content.tsx
@@ -7,7 +7,7 @@ const ContactContent = () => {
 
   return ( 
     <div className="flex w-full justify-between items-center">
-      <div className="hidden max-h-[900px] xl:flex lg:flex">
+      <div className="hidden max-h-[900px] xl:flex lg:flex" data-testid="desktop">
 
         <Image src={ contactImg } alt="Contact Form Image" />
         
@@ -15,7 +15,7 @@ const ContactContent = () => {
       
       <div className="w-full lg:w-1/2 lg:px-32 px-5 md:px-10 my-10 flex flex-col">
 
-        <div className="lg:hidden absolute right-0 top-[6rem]">
+        <div className="lg:hidden absolute right-0 top-[6rem]" data-testid="mobile">
           <Image src= {contactMobileImg} alt="contact form mobile image" width={150} height={180} />
         </div>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This pull request adds a test to check if both the contact us image on the desktop and the background image on the mobile render well.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves: <!-- Add issue number here, i.e. #27. --> #131 
<!-- If this PR fixes multiple issues, copy previous line for each issue that this PR addresses -->

## Motivation and Context
It ensures the contact us images render as expected. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I used cypress chrome desktop to check if the test written works well in all the cases including when the image is not supplied.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if a
<img width="1273" alt="Screen Shot 2023-05-15 at 15 29 21" src="https://github.com/TechIsHiring/techishiring-website/assets/37863089/3d3fcff7-5d1e-4fb4-9fa7-fcab65ece147">
ppropriate):

