### PR TITLE
refactor: import Heading instead of Text from chakra-ui for rendering h1

### DIFF
--- a/cypress/e2e/homepage.cy.ts
+++ b/cypress/e2e/homepage.cy.ts
@@ -8,7 +8,7 @@ describe("Homepage", () => {
   it("should display the homepage", () => {
     cy.title().should("include", "TechIsHiring");
     cy.get("header").should("be.visible");
-    cy.get('.sticky > :nth-child(1) > a > .chakra-text').contains('TechIsHiring');
+    cy.get('.sticky > :nth-child(1) > a > .chakra-heading').contains('TechIsHiring');
     cy.get('header > div > nav > ul').should('be.visible');
 
     validateFooter('desktop')

--- a/src/components/atoms/logo/logo.tsx
+++ b/src/components/atoms/logo/logo.tsx
@@ -1,12 +1,12 @@
 import Link from "components/atoms/link/link";
-import { Text } from "@chakra-ui/react";
+import { Heading } from "@chakra-ui/react";
 
 const Logo = () => {
   return (
     <Link href="/">
-      <Text fontSize="2xl" className="logo">
+      <Heading as="h1" fontSize="1.5em" fontFamily="HirukoPro-Black" className="logo">
         TechIsHiring
-      </Text>
+      </Heading>
     </Link>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

TechIsHiring website is missing an h1 which was revealed during an accessibility audit by @colabottles. I have refactored the logo component that was responsible for rendering the content by importing chakra-ui "Heading" component instead of the "Text" component, thus rendering the proper h1 within the Heading component instead of the paragraph tag. 

I also encountered an issue where chakra-ui default styles were overriding the previous intended styles (namely the default font sizing of a Heading component is different from a Text component as well as the font family), so I opted to use chakra-ui's documentation recommendation for overriding the styles instead of a !important on the global CSS. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See issue #146 

Resolves: #146
<!-- If this PR fixes multiple issues, copy previous line for each issue that this PR addresses -->
- [x] Hierarchy of heading levels for screen reader and users of keyboard for navigation.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is required because headings directly impact the user experience. According to WebAIM’s screen reader user survey, 68.8% of the 1,224 respondents use headings to navigate pages. [Screen Reader Survey](https://webaim.org/projects/screenreadersurvey8/#finding)
<!--- If it fixes an open issue, please link to the issue here. -->
closes #146 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I tested the changes by checking through my browser dev tools after running the changes locally. See the screenshots below for before/after changes were implemented. 

Update: Cypress tests were refactored for end-to-end testing to ensure the homepage is loaded properly.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

### Before
<img width="1345" alt="Screenshot 2023-06-12 at 1 06 13 PM" src="https://github.com/TechIsHiring/techishiring-website/assets/93563580/43e84c64-44d7-4469-b65d-a5d397849b7f">

### After
<img width="1345" alt="Screenshot 2023-06-12 at 1 06 03 PM" src="https://github.com/TechIsHiring/techishiring-website/assets/93563580/f537cdba-f711-4f70-9612-24044b8dffd3">

