### PR TITLE
test: update cypress, add component testing in CI, add Cypress Cloud

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -54,13 +54,6 @@ jobs:
           # Disable running of tests within install job
           runTests: false
 
-      - name: Save build folder
-        uses: actions/upload-artifact@v3
-        with:
-          name: build
-          if-no-files-found: error
-          path: dist
-
   cypress-run-e2e:
 
     name: Run End-to-End Tests
@@ -76,11 +69,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Download the build folder
-        uses: actions/download-artifact@v3
-        with:
-          name: build
 
       - name: Cypress run
         uses: cypress-io/github-action@v5.0.9
@@ -111,11 +99,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Download the build folder
-        uses: actions/download-artifact@v3
-        with:
-          name: build
 
       - name: Cypress run
         uses: cypress-io/github-action@v5.0.9

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -41,9 +41,9 @@ jobs:
       - run: npm run format
 
 
-  cypress-run:
+  cypress-run-e2e:
 
-    name: Run Cypress Tests
+    name: Run End-to-End Tests
     runs-on: ubuntu-latest
     container: cypress/browsers:node12.18.3-chrome87-ff82
     steps:
@@ -62,3 +62,25 @@ jobs:
           # Specify Browser since container image is compile with Firefox
           browser: chrome
           start: npm run dev
+                      
+  cypress-run-component:
+
+    name: Run Component Tests
+    runs-on: ubuntu-latest
+    container: cypress/browsers:node12.18.3-chrome87-ff82
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v5.0.9
+        with:
+          # Specify Browser since container image is compile with Firefox
+          browser: chrome
+          component: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - marktnoonan/cypress-updates
   pull_request:
     branches:
       - main
@@ -40,21 +41,47 @@ jobs:
       - run: npm ci
       - run: npm run format
 
-
-  cypress-run-e2e:
-
-    name: Run End-to-End Tests
+  cypress-install:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node12.18.3-chrome87-ff82
+    container: cypress/browsers:node16.16.0-chrome107-ff107-edge
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Use Node.js
-        uses: actions/setup-node@v3
+      - name: Cypress install
+        uses: cypress-io/github-action@v5.8.3
         with:
-          node-version: 16
-      - run: npm ci
+          # Disable running of tests within install job
+          runTests: false
+          build: npm run build
+
+      - name: Save build folder
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          if-no-files-found: error
+          path: dist
+
+  cypress-run-e2e:
+
+    name: Run End-to-End Tests
+    needs: cypress-install
+    runs-on: ubuntu-latest
+    container: cypress/browsers:node16.16.0-chrome107-ff107-edge
+    strategy:
+      # don't fail the entire matrix on failure
+      fail-fast: false
+      matrix:
+        # run copies of the current job in parallel
+        containers: [1, 2]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download the build folder
+        uses: actions/download-artifact@v3
+        with:
+          name: build
 
       - name: Cypress run
         uses: cypress-io/github-action@v5.0.9
@@ -62,21 +89,34 @@ jobs:
           # Specify Browser since container image is compile with Firefox
           browser: chrome
           start: npm run dev
+          wait-on: 'http://localhost:3000'
+          record: true
+          parallel: true 
+          group: e2e
+        env: 
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                       
   cypress-run-component:
 
     name: Run Component Tests
+    needs: cypress-install
     runs-on: ubuntu-latest
-    container: cypress/browsers:node12.18.3-chrome87-ff82
+    container: cypress/browsers:node16.16.0-chrome107-ff107-edge
+    strategy:
+      # don't fail the entire matrix on failure
+      fail-fast: false
+      matrix:
+        # run copies of the current job in parallel
+        containers: [1, 2]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Use Node.js
-        uses: actions/setup-node@v3
+      - name: Download the build folder
+        uses: actions/download-artifact@v3
         with:
-          node-version: 16
-      - run: npm ci
+          name: build
 
       - name: Cypress run
         uses: cypress-io/github-action@v5.0.9
@@ -84,3 +124,9 @@ jobs:
           # Specify Browser since container image is compile with Firefox
           browser: chrome
           component: true
+          record: true
+          parallel: true
+          group: component
+        env: 
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           # Disable running of tests within install job
           runTests: false
-          build: npm run build
 
       - name: Save build folder
         uses: actions/upload-artifact@v3

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - dev
-      - marktnoonan/cypress-updates
   pull_request:
     branches:
       - main
@@ -65,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         # run copies of the current job in parallel
-        containers: [1, 2]
+        containers: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -95,7 +94,7 @@ jobs:
       fail-fast: false
       matrix:
         # run copies of the current job in parallel
-        containers: [1, 2]
+        containers: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
+    baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "cypress";
 
 export default defineConfig({
+  projectId: "1nng13",
   e2e: {
     baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {

--- a/cypress/e2e/contactuspage.cy.ts
+++ b/cypress/e2e/contactuspage.cy.ts
@@ -1,7 +1,7 @@
 
 describe("Contact Us Image Rendering", () => {
     beforeEach(() => {
-        cy.visit("http://localhost:3000/contact",  { timeout: 30000 });
+        cy.visit("/contact",  { timeout: 30000 });
       });
 
     it("Image rendering on desktop", () =>{

--- a/cypress/e2e/homepage.cy.ts
+++ b/cypress/e2e/homepage.cy.ts
@@ -2,7 +2,7 @@ import validateFooter from "../util/validateFooter";
 
 describe("Homepage", () => {
   beforeEach(() => {
-    cy.visit("http://localhost:3000",  { timeout: 30000 });
+    cy.visit("/",  { timeout: 30000 });
   });
 
   it("should display the homepage", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15500,13 +15500,13 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.12.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.12.0.tgz",
-      "integrity": "sha512-UU5wFQ7SMVCR/hyKok/KmzG6fpZgBHHfrXcHzDmPHWrT+UUetxFzQgt7cxCszlwfozckzwkd22dxMwl/vNkWRw==",
+      "version": "12.17.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.1.tgz",
+      "integrity": "sha512-eKfBgO6t8waEyhegL4gxD7tcI6uTCGttu+ZU7y9Hq8BlpMztd7iLeIF4AJFAnbZH1xjX+wwgg4cRKFNSvv3VWQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.10",
+        "@cypress/request": "^2.88.11",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -15543,7 +15543,7 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
@@ -15731,9 +15731,9 @@
       "dev": true
     },
     "node_modules/cypress/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -41582,12 +41582,12 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.12.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.12.0.tgz",
-      "integrity": "sha512-UU5wFQ7SMVCR/hyKok/KmzG6fpZgBHHfrXcHzDmPHWrT+UUetxFzQgt7cxCszlwfozckzwkd22dxMwl/vNkWRw==",
+      "version": "12.17.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.1.tgz",
+      "integrity": "sha512-eKfBgO6t8waEyhegL4gxD7tcI6uTCGttu+ZU7y9Hq8BlpMztd7iLeIF4AJFAnbZH1xjX+wwgg4cRKFNSvv3VWQ==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^2.88.10",
+        "@cypress/request": "^2.88.11",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -41624,7 +41624,7 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
@@ -41746,9 +41746,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@vitejs/plugin-react": "^3.1.0",
     "autoprefixer": "^10.4.7",
     "babel-loader": "^8.2.5",
-    "cypress": "^12.12.0",
+    "cypress": "^12.17.1",
     "eslint": "8.26.0",
     "eslint-config-next": "^13.2.4",
     "eslint-plugin-storybook": "^0.6.11",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves: #152

<!-- If this PR fixes multiple issues, copy previous line for each issue that this PR addresses -->

## Motivation and Context

I realized when we set up component testing, we did not set it to run in GitHub Actions for this project. Also in talking with Chad we decided to set up a Cypress Cloud project to help with test times by running things in parallel. This also gives us a place to review results and assets like videos/screenshots from tests.

**The Cloud integration will fail until we set a CYPRESS_RECORD_KEY environment variable** in this repository. [This run](https://cloud.cypress.io/projects/1nng13/runs/1/specs) was recorded against my fork of this project.

Additionally I've made a couple of other changes around the testing setup, lets go through them file by file:

### `code-quality.yml`

* Add `cypress-install` step job, needed for parallelization - it runs `npm ci` and provides a common starting point for the parallel runs.
* Updated the container used for tests to get a more recent version of chrome (107).
* Set failure policy and number of containers to use for parellization
* Use latest version of Cypress's github action
* Add `wait-on: 'http://localhost:3000'` to ensure Next dev server has properly stood up before e2e testing begins.
* add `cypress-run-component` job and rename `cypress-run` to `cypress-run-e2e`, and give each one a matching `group`. This allows results from the two separate sets of test to be merged in a single "run" within Cypress.
* add references to secrets `GITHUB_TOKEN` and `CYPRESS_RECORD_KEY`. We must add the `CYPRESS_RECORD_KEY` for the project, but the `GITHUB_TOKEN` is provided automatically when the action runs - we do not need anybody to generate a github authentication token.

### `cypress.config.ts`

* add project ID to connect this project to Cypress Cloud
* add base URL to avoid repetition in e2e tests - this also avoids an annoying page refresh at the start of e2e tests when developing locally, while Cypress "switches" to the `visit`ed URL.

### `cypress/e2e/contactuspage.cy.ts` and `cypress/e2e/contactuspage.cy.ts`

Remove `http://localhost:3000` from tests, as that is now configured as the `baseUrl` for this project.

### `package.json`

Update Cypress to the latest version.

## How Has This Been Tested?

Here is an example run showing the e2e and component tests have both run, and been parallelized and recorded to Cypress Cloud.

## Screenshots (if appropriate):

Run information in Cypress cloud.

<img width="961" alt="Screenshot 2023-07-16 at 4 53 48 PM" src="https://github.com/TechIsHiring/techishiring-website/assets/8340719/16ebfdea-b3d9-4c19-862a-f3994f00f2d8">
