### PR TITLE
144 process-email type validation with zod

### DIFF
--- a/src/pages/api/process-email.ts
+++ b/src/pages/api/process-email.ts
@@ -1,8 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import sgMail from "@sendgrid/mail";
+import { z } from "zod";
+
+// Define The Zod schema for the request body
+const Email = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  message: z.string(),
+});
 
 interface ExtendedNextApiRequest extends NextApiRequest {
-  body: Email
+  body: z.infer<typeof Email>;
 }
 
 export default async function handleSubscribe(

--- a/src/pages/api/process-email.ts
+++ b/src/pages/api/process-email.ts
@@ -23,6 +23,14 @@ export default async function handleSubscribe(
   const badRequest = req.method !== "POST" || requestEmpty;
   if( badRequest ) return res.status(400).json({ data: "Please send a properly formatted request" });
 
+  // Validate the request body against the Zod schema
+  try {
+    Email.parse(req.body);
+  } catch (error) {
+    console.error("Request body validation failed:", error);
+    return res.status(400).json({ data: "Invalid request body" });
+  }
+
   sgMail.setApiKey(process.env.NEXT_PUBLIC_SENDGRID_API_KEY as string);
   
   const msg = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

implementing type validation for the process-email API
such that the Email object has three properties.
name: string,
email: string, which is an email,
message: string

Resolves: <!-- Add issue number here, i.e. #27. -->

#144 

## Motivation and Context

<!--- If it fixes an open issue, please link to the issue here. -->
#144 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Sent a successful request which was well-formatted and no errors occurred.
Sent an invalid email and an error occurred.
Send an invalid datatype and an error occurred

<!--- Include details of your testing environment, and the tests you ran to -->
ran the server on local environment and used postman to hit the API

## Screenshots (if appropriate):

valid request:
![valid](https://github.com/TechIsHiring/techishiring-website/assets/119438857/e17e986b-5bec-4090-b5fa-be02f57e6340)

invalid email: 
![invlaid email](https://github.com/TechIsHiring/techishiring-website/assets/119438857/6822e774-825b-424b-adfc-de201882f8e6)

invalid datatype:
![invalid datatype](https://github.com/TechIsHiring/techishiring-website/assets/119438857/f8954f57-0cc6-4fd3-bf25-dd29909b7b93)
