### PR TITLE
Dg fix issue 159

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[TechIsHiring Website Code of Conduct](https://github.com/TechIsHiring/techishiring-website/blob/dev/CODE_OF_CONDUCT.md).
+[TechIsHiring Website Code of Conduct](https://github.com/techishiring/techishiring-websiteblob/dev/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <techishiring@gmail.com>.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[TechIsHiring Website Code of Conduct](https://github.com/techishiring/techishiring-websiteblob/dev/CODE_OF_CONDUCT.md).
+[TechIsHiring Website Code of Conduct](https://github.com/TechIsHiring/techishiring-website/blob/dev/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <techishiring@gmail.com>.
 


### PR DESCRIPTION
Fix issue #159 broken code of conduct link

## Description

Changed link from:
https://github.com/techishiring/techishiring-websiteblob/dev/CODE_OF_CONDUCT.md
to:
https://github.com/TechIsHiring/techishiring-website/blob/dev/CODE_OF_CONDUCT.md

## Related Issue
https://github.com/TechIsHiring/techishiring-website/issues/159

Resolves: #159 

## Motivation and Context

Important for new contributors to get working link to code of conduct 

## How Has This Been Tested?
Tested in Github when using my branch
