### PR TITLE
Refactor out header checks in homepage E2E tests

### DIFF
--- a/cypress/e2e/homepage.cy.ts
+++ b/cypress/e2e/homepage.cy.ts
@@ -4,7 +4,6 @@ import validateFooter from "../util/validateFooter";
 describe("Homepage", () => {
   beforeEach(() => {
     cy.visit("/",  { timeout: 30000 });
-    cy.wait(100);
   });
 
   it("should display the homepage", () => {

--- a/cypress/e2e/homepage.cy.ts
+++ b/cypress/e2e/homepage.cy.ts
@@ -1,16 +1,31 @@
+import { validateHeaderLinks, validateHeaderLogo, validateModalMenuLinks } from "../util/validateHeader";
 import validateFooter from "../util/validateFooter";
 
 describe("Homepage", () => {
   beforeEach(() => {
     cy.visit("/",  { timeout: 30000 });
+    cy.wait(100);
   });
 
   it("should display the homepage", () => {
     cy.title().should("include", "TechIsHiring");
-    cy.get("header").should("be.visible");
-    cy.get('.sticky > :nth-child(1) > a > .chakra-heading').contains('TechIsHiring');
-    cy.get('header > div > nav > ul').should('be.visible');
+    
+    validateHeaderLogo();
+    validateHeaderLinks();
 
-    validateFooter('desktop')
+    validateFooter('desktop');
   });
+
+  it("should display the homepage on mobile", () => {
+    cy.viewport('iphone-5');
+
+    cy.title().should("include", "TechIsHiring");
+    validateHeaderLogo();
+    cy.get('[data-cy=header]').within(() => {
+      cy.get('nav').click();
+    });
+    validateModalMenuLinks();
+
+    validateFooter('mobile');
+  })
 });

--- a/cypress/util/validateHeader.ts
+++ b/cypress/util/validateHeader.ts
@@ -1,0 +1,36 @@
+export const validateHeaderLogo = () => {
+
+    cy.log('-----START HEADER LOGO-----')
+    // since both mobile and desktop versions are in the DOM as the same time, we scope with [data-cy]
+    cy.get('[data-cy=header]').within(() => {
+        cy.validateLink('TechIsHiring', '/')
+    })
+    // test the main navigation links for the site
+    cy.log('-----END HEADER LOGO-----')
+}
+
+const validateLinks = () => {
+    cy.validateLink('Home', '/')
+    cy.validateLink('Newsletter', 'https://newsletter.techishiring.com/', 'new tab')
+    cy.validateLink('About', '/about')
+    cy.validateLink('Contact Us', '/contact')
+}
+
+export const validateHeaderLinks = () => {
+    cy.log('-----START HEADER LINKS-----')
+    cy.get('[data-cy=header]').within(() => {
+        validateLinks()
+    })
+    // test the main navigation links for the site
+    cy.log('-----END HEADER LINKS-----')
+}
+
+export const validateModalMenuLinks = () => {
+    cy.log('-----START MODAL MENU LINKS-----')
+    // since both mobile and desktop versions are in the DOM as the same time, we scope with [data-cy]
+    cy.get('[role=dialog]').within(() => {
+        validateLinks()
+    })
+    // test the main navigation links for the site
+    cy.log('-----END MODAL MENU LINKS-----')
+}

--- a/src/components/organisms/header/header.tsx
+++ b/src/components/organisms/header/header.tsx
@@ -6,7 +6,7 @@ const Header = () => {
   const navList = useMainNav();
 
   return (
-    <header className="flex justify-center sticky top-0 z-10 w-full border-b bg-white py-2">
+    <header data-cy="header" className="flex justify-center sticky top-0 z-10 w-full border-b bg-white py-2">
       <div className="flex items-center w-full 3xl:w-max-screen-size justify-between px-4 h-24">
         <Logo />
         <MainNav navList={navList} />


### PR DESCRIPTION
## Description

Created validateHeader util module with helper methods similar to validateFooter, and updated homepage E2E tests to use these, adding distinct test for mobile as well. 

## Related Issue

#121 - provides some E2E coverage instead of component as it seems there's technical impediment for the latter - see comments in this issue

## Motivation and Context
Ensure more consistent approach between footer and header checks. And, adding some coverage for modal menu on mobile.

## How Has This Been Tested?

Tested locally on Chrome

## Screenshots (if appropriate):
n/a